### PR TITLE
feat: replacing assessment plan placeholders

### DIFF
--- a/compliance/assessment-plan.json
+++ b/compliance/assessment-plan.json
@@ -3,7 +3,7 @@
   "assessment-assets": {
    "assessment-platforms": [
     {
-     "title": "REPLACE_ME",
+     "title": "Cloud Native Security Controls Catalog",
      "uses-components": [
       {
        "component-uuid": "1026fea3-20f9-4134-bd71-5fd56522fe4c"
@@ -71,7 +71,7 @@
    ]
   },
   "import-ssp": {
-   "href": "REPLACE_ME"
+   "href": "Import SSP href has not been set."
   },
   "local-definitions": {
    "activities": [


### PR DESCRIPTION
## Description

This PR updates the `"REPLACE_ME"` strings that serve as placeholders in the `assessment-plan.json`. The updates include a title reference to the "Cloud Native Security Controls Catalog." The `assessment-plan.metadata.title` placeholder was not removed.  

## Related Issues

* Fixes Issue #8 

## Review Hints

* Review [OSCAL Assessment Plan Model](https://pages.nist.gov/OSCAL-Reference/models/v1.1.3/assessment-plan/json-reference/#/assessment-plan/back-matter)
* @jpower432 Please let me know if the `metadata` section needs additional updates. 